### PR TITLE
typo

### DIFF
--- a/usacloud/tools/chocolateyuninstall.ps1
+++ b/usacloud/tools/chocolateyuninstall.ps1
@@ -10,7 +10,7 @@ $packageArgs = @{
 # Only necessary if you did not unpack to package directory - see https://chocolatey.org/docs/helpers-uninstall-chocolatey-zip-package
 $os = Get-WmiObject -Class Win32_OperatingSystem;
 if ($os.OSarchitecture.Contains("64")) {
-  Uninstall-ChocolateyZipPackage -PackageName $packageArgs['packageName'] -ZipFileName $packageArgs['zipFileName']
-} else {
   Uninstall-ChocolateyZipPackage -PackageName $packageArgs['packageName'] -ZipFileName $packageArgs['zipFileName64']
+} else {
+  Uninstall-ChocolateyZipPackage -PackageName $packageArgs['packageName'] -ZipFileName $packageArgs['zipFileName']
 }


### PR DESCRIPTION
The zipFileName 64 is now called when the OS contains 64 and not the other way around.