### PR TITLE
fix: chocolateyではlicenseタグではなくlicenseUrlを使用する必要があるため、修正

### DIFF
--- a/usacloud/usacloud.nuspec
+++ b/usacloud/usacloud.nuspec
@@ -14,7 +14,7 @@
     <projectSourceUrl>https://github.com/sacloud/usacloud</projectSourceUrl>
     <iconUrl>https://cdn.rawgit.com/sacloud/images/1fe15a73/usacloud_logo.svg</iconUrl>
     <copyright>Kazumichi Yamamoto (@yamamoto-febc)</copyright>
-    <license type="expression">Apache-2.0</license>
+    <licenseUrl>https://github.com/sacloud/usacloud/blob/master/LICENSE</licenseUrl>
     <docsUrl>https://docs.usacloud.jp/usacloud/</docsUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <packageSourceUrl>https://github.com/sacloud/chocolatey-usacloud</packageSourceUrl>


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #

### このPRはどういう変更を行いますか？

- chocolateyでは、 `license` タグではなく `licenseUrl` タグを使用する必要があるため、修正

### ドキュメントの変更は必要ですか？

- 不要