### PR TITLE
fix: BOM付きUTF-8では、PowerShellで日本語が文字化けしてしまうため、BOMなしUTF-8で出力するように修正

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -146,12 +146,12 @@ jobs:
           Set-Location -Path .\usacloud
 
           (Get-Content '.\usacloud.nuspec' -Raw).Replace("__VERSION__", $packageVersion) |
-            Out-File '.\usacloud.nuspec' -Encoding utf8
+            Out-File '.\usacloud.nuspec' -Encoding utf8NoBOM
           echo "[INFO] --- usacloud.nuspec ---"
           Get-Content '.\usacloud.nuspec'
 
           (Get-Content '.\tools\chocolateyinstall.ps1' -Raw).Replace("__VERSION__", "v$version").Replace("__HASH32__", $hash32).Replace("__HASH64__", $hash64) |
-            Out-File '.\tools\chocolateyinstall.ps1' -Encoding utf8
+            Out-File '.\tools\chocolateyinstall.ps1' -Encoding utf8NoBOM
           echo "[INFO] --- chocolateyinstall.ps1 ---"
           Get-Content '.\tools\chocolateyinstall.ps1'
 


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #

### このPRはどういう変更を行いますか？

- スクリプトの生成時に日本語が文字化けする問題に対応しました。
  - BOM付きUTF-8では、PowerShellで日本語が文字化けしてしまうため、BOMなしUTF-8で出力するように修正しました。

### ドキュメントの変更は必要ですか？

- 不要