### PR TITLE
fix: shift-jisで読み込まれてしまうようなので、BOM付きUTF-8で書き出すように再修正

### DIFF
--- a/.github/workflows/chocolatey.yml
+++ b/.github/workflows/chocolatey.yml
@@ -150,8 +150,9 @@ jobs:
           echo "[INFO] --- usacloud.nuspec ---"
           Get-Content '.\usacloud.nuspec'
 
-          (Get-Content '.\tools\chocolateyinstall.ps1' -Raw).Replace("__VERSION__", "v$version").Replace("__HASH32__", $hash32).Replace("__HASH64__", $hash64) |
-            Out-File '.\tools\chocolateyinstall.ps1' -Encoding utf8NoBOM
+          # Chocolatey は Windows PowerShell 5.1 で ps1 を実行するため、BOM付きUTF-8が必要
+          $content = (Get-Content '.\tools\chocolateyinstall.ps1' -Raw).Replace("__VERSION__", "v$version").Replace("__HASH32__", $hash32).Replace("__HASH64__", $hash64)
+          [System.IO.File]::WriteAllText((Resolve-Path '.\tools\chocolateyinstall.ps1').Path, $content, [System.Text.UTF8Encoding]::new($true))
           echo "[INFO] --- chocolateyinstall.ps1 ---"
           Get-Content '.\tools\chocolateyinstall.ps1'
 


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

Fixes #

### このPRはどういう変更を行いますか？

- BOMなしだと、どうやらShift-JISで読み込まれてしまうようなので、BOM付きUTF-8で書き出すように再修正しました。

### ドキュメントの変更は必要ですか？

- 不要
